### PR TITLE
Template engine loads assemblies multiple times and breaks resolution of XAML resources

### DIFF
--- a/RazorTemplating.sln
+++ b/RazorTemplating.sln
@@ -45,7 +45,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleAzureFunction.Net6.0
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleWebApp.Net6_0", "examples\Mvc\ExampleWebApp.Net6_0\ExampleWebApp.Net6_0.csproj", "{5F65F2B4-F330-49C7-B410-ED791322A0E7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleMinApiApp.Net6_0", "examples\Api\ExampleMinApiApp.Net6_0\ExampleMinApiApp.Net6_0.csproj", "{6A16ECC1-3883-4EF8-8224-E50AF071A478}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleMinApiApp.Net6_0", "examples\Api\ExampleMinApiApp.Net6_0\ExampleMinApiApp.Net6_0.csproj", "{6A16ECC1-3883-4EF8-8224-E50AF071A478}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.Windows.Desktop.WPF", "examples\Desktop\Example.Windows.Desktop.WPF\Example.Windows.Desktop.WPF.csproj", "{7DAFF123-9C3C-4BAE-9BA7-AAEA121D9F5E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Desktop", "Desktop", "{858C6EFB-A924-4909-8E2F-C88FC2A31FED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,6 +93,10 @@ Global
 		{6A16ECC1-3883-4EF8-8224-E50AF071A478}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A16ECC1-3883-4EF8-8224-E50AF071A478}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A16ECC1-3883-4EF8-8224-E50AF071A478}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DAFF123-9C3C-4BAE-9BA7-AAEA121D9F5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DAFF123-9C3C-4BAE-9BA7-AAEA121D9F5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DAFF123-9C3C-4BAE-9BA7-AAEA121D9F5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DAFF123-9C3C-4BAE-9BA7-AAEA121D9F5E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -109,6 +117,8 @@ Global
 		{A9262317-1042-45FF-B2C0-997D48FB450E} = {D301739A-C3C1-4BC7-A595-B9E5E33006E7}
 		{5F65F2B4-F330-49C7-B410-ED791322A0E7} = {1C91D7E6-F2B9-4F58-BCA8-8E428698CB2F}
 		{6A16ECC1-3883-4EF8-8224-E50AF071A478} = {08B94DF1-05A5-436C-9383-D9867A294733}
+		{7DAFF123-9C3C-4BAE-9BA7-AAEA121D9F5E} = {858C6EFB-A924-4909-8E2F-C88FC2A31FED}
+		{858C6EFB-A924-4909-8E2F-C88FC2A31FED} = {AD88CAC8-F022-4702-8073-8E6EF62AADD7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73728C09-FCFE-43D7-BEF4-B24DF6A38562}

--- a/examples/Desktop/Example.Windows.Desktop.WPF/Example.Windows.Desktop.WPF.csproj
+++ b/examples/Desktop/Example.Windows.Desktop.WPF/Example.Windows.Desktop.WPF.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Razor.Templating.Core\Razor.Templating.Core.csproj" />
-    <ProjectReference Include="..\ExampleAppRazorTemplates\ExampleRazorTemplatesLibrary.csproj" />
+    <ProjectReference Include="..\..\..\src\Razor.Templating.Core\Razor.Templating.Core.csproj" />
+    <ProjectReference Include="..\..\Templates\ExampleAppRazorTemplates\ExampleRazorTemplatesLibrary.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/Desktop/Example.Windows.Desktop.WPF/MainWindow.xaml.cs
+++ b/examples/Desktop/Example.Windows.Desktop.WPF/MainWindow.xaml.cs
@@ -46,9 +46,6 @@ namespace Example.Windows.Desktop.WPF
 
                 var html = await RazorTemplateEngine.RenderAsync("/Views/ExampleView.cshtml", model, viewData);
                 textBlock.Text = html;
-
-                // after a template has been rendered, XAML view can no longer be resolved
-                var view = new MainWindow();
             }
             catch (System.Exception exception)
             {

--- a/examples/Desktop/Example.Windows.Desktop.WPF/MainWindow.xaml.cs
+++ b/examples/Desktop/Example.Windows.Desktop.WPF/MainWindow.xaml.cs
@@ -46,6 +46,9 @@ namespace Example.Windows.Desktop.WPF
 
                 var html = await RazorTemplateEngine.RenderAsync("/Views/ExampleView.cshtml", model, viewData);
                 textBlock.Text = html;
+
+                // after a template has been rendered, XAML view can no longer be resolved
+                var view = new MainWindow();
             }
             catch (System.Exception exception)
             {

--- a/src/Razor.Templating.Core/Infrastructure/ApplicationPartsManager.cs
+++ b/src/Razor.Templating.Core/Infrastructure/ApplicationPartsManager.cs
@@ -57,11 +57,12 @@ namespace Razor.Templating.Core.Infrastructure
             var binPath = Path.GetDirectoryName(executingAssemblyLocation);
             var dllFiles = Directory.GetFiles(binPath!, "*.dll", SearchOption.TopDirectoryOnly);
             Logger.Log($"Found {dllFiles?.Length} dll files in executing assembly path");
+
             foreach (var dll in dllFiles ?? Array.Empty<string>())
             {
                 try
                 {
-                    var loadedAssembly = Assembly.LoadFile(dll);
+                    var loadedAssembly = Assembly.LoadFrom(dll);
                     assemblies.Add(loadedAssembly);
                 }
                 catch (Exception e)


### PR DESCRIPTION
When the engine is initialized, assemblies from the bin folder might be loaded into the current context although they are already loaded. This causes runtime errors, e.g. it is no longer possible to instantiate XAML views in a WPF application, because the XAML resource can no longer be resolved. Instead, the following exception is raised:

`System.Exception: 'The component 'Example.Windows.Desktop.WPF.MainWindow' does not have a resource identified by the URI '/Example.Windows.Desktop.WPF;component/mainwindow.xaml'.'
`

I narrowed the problem down to method `ApplicationPartsManager.GetAllBinDirectoryAssemblies()` where the problem can be fixed by replacing the call `Assembly.LoadFile` with a call to `Assembly.LoadFrom` (also see the comment by Hans Passant here https://stackoverflow.com/q/56146804/40347)

